### PR TITLE
implement fmt for Expression and add parser::eval

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,9 +1,9 @@
 use core::{
-    fmt::{Display, Formatter, self, Write},
+    fmt::{Display, Formatter, self},
     str::FromStr,
 };
 
-use heapless::{LinearMap, String};
+use heapless::LinearMap;
 use heapless::Vec;
 
 use crate::{
@@ -82,11 +82,10 @@ impl<const E: usize> FromStr for Expression<E> {
 //TODO: write as infix instead of postfix
 impl<const E: usize> fmt::Display for Expression<E> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.tokens.iter().fold(String::<64>::new(), |acc, token| { //TODO:!!!I'm not sure how to assign the maximum size
-            let mut wr = String::new();
-            write!(wr, "{}", format_args!("{}{}", acc, token)).unwrap();
-            wr
-        }))
+        self.tokens.iter().try_for_each(|token| {
+            write!(f, "{}", token)
+        })?;
+        Ok(())
     }
 }
 

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,9 +1,9 @@
 use core::{
-    fmt::{Display, Formatter},
+    fmt::{Display, Formatter, self, Write},
     str::FromStr,
 };
 
-use heapless::LinearMap;
+use heapless::{LinearMap, String};
 use heapless::Vec;
 
 use crate::{
@@ -79,6 +79,17 @@ impl<const E: usize> FromStr for Expression<E> {
     }
 }
 
+//TODO: write as infix instead of postfix
+impl<const E: usize> fmt::Display for Expression<E> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.tokens.iter().fold(String::<64>::new(), |acc, token| { //TODO:!!!I'm not sure how to assign the maximum size
+            let mut wr = String::new();
+            write!(wr, "{}", format_args!("{}{}", acc, token)).unwrap();
+            wr
+        }))
+    }
+}
+
 impl<const E: usize> Expression<E> {
     pub fn new(tokens: Vec<Token, E>) -> Self {
         Expression { tokens }
@@ -117,7 +128,7 @@ impl<const E: usize> Expression<E> {
                         .push(Token::Number(result))
                         .map_err(|_| Error::NotEnoughMemory)?;
                 }
-                _ => unimplemented!(), //TODO: create value enum and implement value precedence to sort and combine by num, then var, then func
+                _ => return Err(Error::InvalidSyntax), //TODO: create value enum and implement value precedence to sort and combine by num, then var, then func
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,10 @@ mod token;
 pub use expression::{Approx, Expression};
 pub use parser::approx as parse_approximation;
 pub use parser::math_expr as parse_math_expression;
+pub use parser::eval as parse_evaluation;
 
 #[derive(Debug)]
 pub enum Error {
     NotEnoughMemory,
+    InvalidSyntax,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,12 +15,19 @@ fn main() {
             .read_line(&mut input)
             .expect("Failed to read line");
 
-        let result = rcas::parse_approximation(&input, &map);
+        let eval_result = rcas::parse_evaluation::<500>(&input);
+        let approx_result = rcas::parse_approximation(&input, &map);
 
-        if result.is_ok() {
-            println!("{}", result.unwrap());
+        if eval_result.is_ok() {
+            println!("eval: {}", eval_result.unwrap().to_string());
         } else {
-            println!("{:?}", result.unwrap_err());
+            println!("eval: {:?}", eval_result.unwrap_err());
+        }
+
+        if approx_result.is_ok() {
+            println!("approx: {}", approx_result.unwrap().to_string());
+        } else {
+            println!("approx: {:?}", approx_result.unwrap_err());
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,9 @@
 use core::str::FromStr;
 
-use heapless::LinearMap;
-use heapless::Vec;
+use heapless::{
+    LinearMap, 
+    Vec,
+};
 
 use nom::{
     branch::alt,
@@ -78,4 +80,12 @@ pub fn approx<const E: usize, const N: usize>(
         Err(_err) => unimplemented!(),
     }
     .approximate(map)
+}
+
+pub fn eval<const E: usize>(input: &str) -> Result<Expression<E>, crate::Error> {
+    match Expression::from_str(input.trim()) {
+        Ok(it) => it,
+        Err(_err) => unimplemented!(),
+    }
+    .evaluate()
 }


### PR DESCRIPTION
I have no idea how to define the string size for fmt. I don't think the user can decide, because it's part of a core trait. it can't be E, because some tokens, namely functions, can be longer than a single character. ~~8*E-7 is the theoretical maximum, but that feels very very large.~~ floats can be way longer than a single character as well.