### PR TITLE
add ExpressionMaps

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -167,7 +167,18 @@ impl<const E: usize> Expression<E> {
             }
         }
 
-        let mut result = exprs
+        let mut ensure_implimentation: Expression<E> = Expression::new(Vec::new());
+        for token in exprs.tokens.iter() {
+            match token {
+                &Token::Terminator => {},
+                _ => {
+                    ensure_implimentation.tokens.push(token.clone())
+                        .map_err(|_| Error::NotEnoughMemory)?;
+                }
+            }
+        }
+
+        let mut result = ensure_implimentation
             .evaluate()?
             .tokens;
 

--- a/src/expression_map.rs
+++ b/src/expression_map.rs
@@ -1,4 +1,4 @@
-use heapless::{Vec, LinearMap,};
+use heapless::{Vec, LinearMap, String,};
 
 use crate::{token::Token, Expression, Error, Approx};
 
@@ -78,5 +78,129 @@ impl<const E: usize, const L: usize> VariableMap<E, L> {
 
     pub fn len(&self) -> usize {
         self.map.len()
+    }
+}
+
+pub struct UserFunctionMap<const E: usize, const L: usize, const V: usize> {
+    function_map: LinearMap<String<8>, Expression<E>, L>,
+    argument_list: LinearMap<String<8>, Vec<char, V>, L>,
+}
+
+impl<const E: usize, const L: usize, const V: usize> ExpressionMap<E> for UserFunctionMap<E, L, V> {
+    fn stack_contains(&self, stack: &Expression<E>) -> bool {
+        for token in stack.tokens.iter() {
+            match token {
+                Token::Func(_) => return true,
+                _ => continue,
+            }
+        }
+        return false;
+    }
+
+    fn evaluate(&self, stack: &Expression<E>) -> Expression<E> {
+        Expression { tokens: stack.tokens.clone() }
+    }
+
+    fn approximate(&self, stack: &Expression<E>) -> Expression<E> {
+        let mut new_tokens = Vec::<Token, E>::new();
+        
+        let mut skip = 0;
+        for (i, token) in stack.tokens.iter().enumerate() {
+            if skip > 0 { //there has to be a better way to do this
+                skip -= 1;
+                continue;
+            }
+            
+            skip = 1; //skip the terminator
+            match token {
+                Token::Func(func) => {
+                    let mut arguments: Vec<Vec::<Token, V>, V> = Vec::new();
+                    let mut argument_approx: Vec<Approx, E> = Vec::new();
+                    let mut argument_count = 0;
+
+                    //fill the arguments vector with Vec::new()
+                    for _ in 1..arguments.capacity() {
+                        arguments.push(Vec::new()).map_err(|_| Error::NotEnoughMemory).unwrap();
+                    }
+
+                    for sub_token in stack.tokens.iter().skip(i + 1) {
+                        match sub_token {
+                            Token::Divider => argument_count += 1,
+                            Token::Terminator => break,
+                            _ => arguments[argument_count].push(sub_token.clone()).unwrap(),
+                        }
+                        skip += 1;
+                    }
+
+                    for vector in arguments.iter().take(argument_count + 1) {
+                        argument_approx
+                            .push(Expression::<V> { tokens: vector.clone() }
+                            .approximate(&Vec::<&dyn ExpressionMap<V>, E>::new()).unwrap()).unwrap();
+                    }
+
+                    for sub_token in self.function_map.get(&func).unwrap().tokens.iter() {
+                        match sub_token {
+                            Token::Var(var) => {
+                                if let Some(approx_token) = match argument_approx[self.argument_list.get(&func).unwrap().binary_search(var).unwrap()] {
+                                    Approx::Num(n) => Some(Token::Number(n)),
+                                    _ => unimplemented!(),
+                                }{
+                                    new_tokens.push(approx_token.clone()).unwrap();
+                                } else {
+                                    new_tokens.push(sub_token.clone()).unwrap();
+                                }
+                            }
+                            _ => new_tokens.push(sub_token.clone()).unwrap(),
+                        }
+                    }
+                }
+                _ => new_tokens.push(token.clone()).unwrap(),
+            }
+        }
+
+        Expression { tokens: new_tokens }
+    }
+}
+
+impl<const E: usize, const L: usize, const V: usize> UserFunctionMap<E, L, V> {
+    pub fn new() -> Self {
+        UserFunctionMap {
+            function_map: LinearMap::<String<8>, Expression<E>, L>::new(),
+            argument_list: LinearMap::<String<8>, Vec<char, V>, L>::new(),
+        }
+    }
+
+    pub fn insert_function(&mut self, name: String<8>, expr: Expression<E>) -> Result<Option<Expression<E>>, Error> {
+        self.function_map.insert(name, expr).map_err(|_| Error::NotEnoughMemory)
+    }
+
+    pub fn insert_arguments(&mut self, name: String<8>, vars: Vec<char, V>) -> Result<Option<Vec<char, V>>, Error> {
+        self.argument_list.insert(name, vars).map_err(|_| Error::NotEnoughMemory)
+    }
+
+    pub fn get_function(&self, name: String<8>) -> Option<&Expression<E>> {
+        self.function_map.get(&name)
+    }
+
+    pub fn get_arguments(&self, name: String<8>) -> Option<&Vec<char, V>> {
+        self.argument_list.get(&name)
+    }
+
+    pub fn remove_function(&mut self, name: String<8>) -> Option<Expression<E>> {
+        self.function_map.remove(&name)
+    }
+
+    pub fn remove_arguments(&mut self, name: String<8>) -> Option<Vec<char, V>> {
+        self.argument_list.remove(&name)
+    }
+
+    pub fn clear(&mut self) {
+        self.function_map.clear();
+        self.argument_list.clear();
+    }
+
+    pub fn len(&self) -> usize {
+        assert!(self.function_map.len() == self.argument_list.len());
+        self.function_map.len()
     }
 }

--- a/src/expression_map.rs
+++ b/src/expression_map.rs
@@ -1,0 +1,82 @@
+use heapless::{Vec, LinearMap,};
+
+use crate::{token::Token, Expression, Error, Approx};
+
+/// parses tokens which need modifiable definition
+pub trait ExpressionMap<const E: usize> {
+    fn stack_contains(&self, stack: &Expression<E>) -> bool;
+    fn evaluate(&self, stack: &Expression<E>) -> Expression<E>;
+    fn approximate(&self, stack: &Expression<E>) -> Expression<E>;
+}
+
+pub struct VariableMap<const E: usize, const L: usize> {
+    map: LinearMap<char, Expression<E>, L>,
+}
+
+impl<const E: usize, const L: usize> ExpressionMap<E> for VariableMap<E, L> {
+    fn stack_contains(&self, stack: &Expression<E>) -> bool {
+        for token in stack.tokens.iter() {
+            match token {
+                Token::Var(_) => return true,
+                _ => continue,
+            }
+        }
+        return false;
+    }
+
+    fn evaluate(&self, stack: &Expression<E>) -> Expression<E> {
+        Expression { tokens: stack.tokens.clone() }
+    }
+
+    fn approximate(&self, stack: &Expression<E>) -> Expression<E> {
+        Expression { tokens: stack.tokens
+        .iter()
+        .map(|token| {
+            match token {
+                Token::Var(var) => {
+                    if let Some(expr) = self.map.get(&var) {
+                        match expr.approximate(&Vec::<&dyn ExpressionMap<E>, 1>::from_slice(&[self]).unwrap()) {
+                            Ok(Approx::Num(n)) => Ok(Some(Token::Number(n))),
+                            Ok(Approx::Undef) => Ok(None),
+                            Err(err) => Err(err),
+                        }
+                    } else {
+                        return Ok(None);
+                    }
+                }
+                _ => Ok(Some(token.clone())),
+            }
+        })
+        .filter_map(Result::transpose)
+        .collect::<Result<Vec<Token, E>, Error>>()
+        .unwrap() }
+    }
+}
+
+impl<const E: usize, const L: usize> VariableMap<E, L> {
+    pub fn new() -> Self {
+        VariableMap {
+            map: LinearMap::<char, Expression<E>, L>::new(),
+        }
+    }
+
+    pub fn insert(&mut self, var: char, expr: Expression<E>) -> Result<Option<Expression<E>>, Error> {
+        self.map.insert(var, expr).map_err(|_| Error::NotEnoughMemory)
+    }
+
+    pub fn get(&self, var: char) -> Option<&Expression<E>> {
+        self.map.get(&var)
+    }
+
+    pub fn remove(&mut self, var: char) -> Option<Expression<E>> {
+        self.map.remove(&var)
+    }
+
+    pub fn clear(&mut self) {
+        self.map.clear();
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod token;
 mod expression_map;
 
 pub use expression::{Approx, Expression};
-pub use expression_map::{ExpressionMap, VariableMap,};
+pub use expression_map::{ExpressionMap, VariableMap,UserFunctionMap,};
 pub use parser::approx as parse_approximation;
 pub use parser::math_expr as parse_math_expression;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,10 @@
 mod expression;
 mod parser;
 mod token;
+mod expression_map;
 
 pub use expression::{Approx, Expression};
+pub use expression_map::{ExpressionMap, VariableMap,};
 pub use parser::approx as parse_approximation;
 pub use parser::math_expr as parse_math_expression;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,27 @@
 use std::{io, str::FromStr};
+use heapless::{String, Vec};
 
-use rcas::{Expression, VariableMap, ExpressionMap,};
+use rcas::{Expression, VariableMap, ExpressionMap, UserFunctionMap,Error,};
 
 fn main() {
     let mut var_map = VariableMap::<500, 52>::new();
     var_map.insert('x', Expression::<500>::from_str("30+20").unwrap()).unwrap(); //simple variable test case
-    let mut map_collection: heapless::Vec<&dyn ExpressionMap<500>, 1> = heapless::Vec::new();
-    map_collection.push(&var_map as &dyn ExpressionMap<500>);
+
+    let mut func_map = UserFunctionMap::<500, 52, 16>::new();
+    func_map.insert_function(String::<8>::from_str("test").unwrap(), Expression::<500>::from_str("y+z+20").unwrap()).unwrap(); //simple function test case
+    func_map.insert_arguments(String::<8>::from_str("test").unwrap(), Vec::from_slice(&['y', 'z']).unwrap())
+        .map_err(|_| Error::NotEnoughMemory).unwrap(); //simple argument test case
+
+    let mut map_collection: Vec<&dyn ExpressionMap<500>, 2> = Vec::new();
+    map_collection.push(&var_map as &dyn ExpressionMap<500>)
+        .map_err(|_| Error::NotEnoughMemory).unwrap();
+    map_collection.push(&func_map as &dyn ExpressionMap<500>)
+        .map_err(|_| Error::NotEnoughMemory).unwrap();
 
     loop {
         println!("Enter a math expression: ");
 
-        let mut input = String::new();
+        let mut input = std::string::String::new();
 
         io::stdin()
             .read_line(&mut input)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
 use std::{io, str::FromStr};
 
-use rcas::Expression;
+use rcas::{Expression, VariableMap, ExpressionMap,};
 
 fn main() {
-    let mut map = heapless::LinearMap::<char, Expression<500>, 52>::new();
-    map.insert('x', rcas::Expression::<500>::from_str("30+20").unwrap()).unwrap(); //simple variable test case
+    let mut var_map = VariableMap::<500, 52>::new();
+    var_map.insert('x', Expression::<500>::from_str("30+20").unwrap()).unwrap(); //simple variable test case
+    let mut map_collection: heapless::Vec<&dyn ExpressionMap<500>, 1> = heapless::Vec::new();
+    map_collection.push(&var_map as &dyn ExpressionMap<500>);
 
     loop {
         println!("Enter a math expression: ");
@@ -15,7 +17,7 @@ fn main() {
             .read_line(&mut input)
             .expect("Failed to read line");
 
-        let result = rcas::parse_approximation(&input, &map);
+        let result = rcas::parse_approximation(&input, &map_collection);
 
         if result.is_ok() {
             println!("{}", result.unwrap());

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -47,6 +47,15 @@ fn parenthesis(i: &str) -> IResult<&str, Token, Error<&str>> {
     ))
 }
 
+fn divider(i: &str) -> IResult<&str, Token, Error<&str>> {
+    let (i, _) = one_of(",")(i)?;
+
+    Ok((
+        i,
+        Token::Divider,
+    ))
+}
+
 fn variable(i: &str) -> IResult<&str, Token, Error<&str>> {
     let (i, c) = anychar(i)?;
 
@@ -59,7 +68,7 @@ fn float(i: &str) -> IResult<&str, Token, Error<&str>> {
 }
 
 fn math_token(i: &str) -> IResult<&str, Token, Error<&str>> {
-    alt((operation, float, parenthesis, variable))(i)
+    alt((operation, float, parenthesis, divider, variable))(i)
 }
 
 pub fn math_expr<const E: usize>(i: &str) -> IResult<&str, Vec<Token, E>, Error<&str>> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,5 @@
 use core::str::FromStr;
 
-use heapless::LinearMap;
 use heapless::Vec;
 
 use nom::{
@@ -16,6 +15,7 @@ use nom::{
 use crate::{
     expression::{Approx, Expression},
     token::{Operation, Token},
+    expression_map::ExpressionMap,
 };
 
 fn operation(i: &str) -> IResult<&str, Token, Error<&str>> {
@@ -71,11 +71,11 @@ pub fn math_expr<const E: usize>(i: &str) -> IResult<&str, Vec<Token, E>, Error<
 
 pub fn approx<const E: usize, const N: usize>(
     input: &str,
-    map: &LinearMap<char, Expression<E>, N>,
+    maps: &Vec<&dyn ExpressionMap<E>, N>,
 ) -> Result<Approx, crate::Error> {
     match Expression::from_str(input.trim()) {
         Ok(it) => it,
         Err(_err) => unimplemented!(),
     }
-    .approximate(map)
+    .approximate(maps)
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -9,6 +9,8 @@ pub enum Token {
     Var(char),
     Paren(bool),
     Func(String<8>),
+    Divider,
+    Terminator,
 }
 
 impl PartialEq for Token {
@@ -35,6 +37,8 @@ impl Display for Token {
             Token::Paren(true) => write!(f, "("),
             Token::Paren(false) => write!(f, ")"),
             Token::Func(func) => write!(f, "{}", func),
+            Token::Divider => write!(f, ","),
+            _ => write!(f, ""),
         }
     }
 }


### PR DESCRIPTION
you might be wondering why I created this to evaluate and approximate a vector of maps. there are a few reasons:
1. architecture: I'm planning to implement all higher-level functionality, like trigonometric simplification, logarithmic simplification, differentiation, integration, and statistics as EvaluationMaps
2. customization: if a user doesn't want a feature, for either memory or space, they can just not add it to the vector; however, if you needed multiple instances of rCAS in a single project, you could enable or disable features for each separate instance
3. extensibility: if a user of the library wants to add more functionality to evaluation or approximation, they don't have to modify the library itself, they can simply implement the trait and add it to the EvaluationMap Vector

note: functions can only have operations to their right and can't process expressions as arguments, which I'm planning to fix when I implement ASTs and recursive descent