### PR TITLE
Adding Vectors and Matrices to the AST and parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /.vscode
+/.idea

--- a/src/expression/expression_tree.rs
+++ b/src/expression/expression_tree.rs
@@ -183,8 +183,14 @@ pub enum Expression {
 
     // Vector
     Vector {
-        backing: AlVec<Expression>, // could use heapless::Vec instead of alloc::vec::Vec
+        backing: AlVec<Expression>,
         size: u8,
+    },
+
+    // Matrix
+    Matrix {
+        backing: AlVec<Expression>,
+        shape: (u8, u8),
     },
 
     //unary operators
@@ -320,6 +326,7 @@ impl Expression {
                     }
                 }
                 Expression::Vector { backing: _, size: _ } => todo!("Figure out conversion rules"),
+                Expression::Matrix { backing: _, shape: (_, _) } => todo!("Figure out conversion rules"),
                 Expression::Function { name: n1, args: a1 } => {
                     let mut args = Vec::new();
 
@@ -465,10 +472,16 @@ impl PartialOrd for Expression {
                     _ => Some(Ordering::Greater),
                 },
             },
-            (_, Expression::Vector{ backing: _, size: _ }) => {
+            (_, Expression::Vector { backing: _, size: _ }) => {
                 todo!("Figure out ordering rules")
             }
-            (Expression::Vector{ backing: _, size: _ }, _) => {
+            (Expression::Vector { backing: _, size: _ }, _) => {
+                todo!("Figure out ordering rules")
+            }
+            (_, Expression::Matrix { backing: _, shape: (_, _) }) => {
+                todo!("Figure out ordering rules")
+            }
+            (Expression::Matrix { backing: _, shape: (_, _) }, _) => {
                 todo!("Figure out ordering rules")
             }
             (Expression::Function { name: n1, args: a1 }, Expression::Function { name: n2, args: a2 }) => a1.partial_cmp(a2).and(n1.partial_cmp(n2)),
@@ -527,6 +540,22 @@ impl fmt::Display for Expression {
                     write!(f, "{}", e)?;
                 }
                 write!(f, ">")
+            }
+
+            Expression::Matrix { backing: vec, shape: (rs, cs) } => {
+                write!(f, "[")?;
+                for r in 0..*rs {
+                    if r > 0 {
+                        write!(f, "; ")?;
+                    }
+                    for c in 0..*cs {
+                        if c > 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{}", vec[(*cs * r + c) as usize])?;
+                    }
+                }
+                write!(f, "]")
             }
             
             Expression::Negate(e) => write!(f, "-({})", e),

--- a/src/modifier/adaptable_modifier.rs
+++ b/src/modifier/adaptable_modifier.rs
@@ -122,10 +122,15 @@ impl Modifier for AdaptableModifier {
 
         match expression {
             Expression::Atom(_) => {}
+            Expression::Vector { backing: vec, size: _ } => {
+                for e in vec {
+                    modified = self.modify(e) || modified;
+                }
+            }
             Expression::Function { name: _, args: a } => {
                 for expr in a {
                     modified = self.modify(expr) || modified;
-                }           
+                }
             }
             Expression::Negate(e1) |
             Expression::Factorial(e1) |

--- a/src/modifier/adaptable_modifier.rs
+++ b/src/modifier/adaptable_modifier.rs
@@ -127,6 +127,11 @@ impl Modifier for AdaptableModifier {
                     modified = self.modify(e) || modified;
                 }
             }
+            Expression::Matrix { backing: vec, shape: (_, _) } => {
+                for e in vec {
+                    modified = self.modify(e) || modified;
+                }
+            }
             Expression::Function { name: _, args: a } => {
                 for expr in a {
                     modified = self.modify(expr) || modified;


### PR DESCRIPTION
### What has been completed
Vectors denoted as `<v_0, v_1, ..., v_i>` for a size `i` are now in the Abstract Syntax Tree representation and can be successfully parsed as well.

### What still needs work
Vectors have not yet been handled during `level_eq` and `conversion`

### Discussion points
Should the `Expression::Vector` enum variant utilize `alloc::vec::Vec` (currently in use under the type alias of `AlVec`) or should it be made into a `heapless::Vec` with an arbitrary max size (i.e. `heapless::Vec<Expression, 8>`)? Would it be expected for users to need a vector of "theoretical" infinite elements?
