### PR TITLE
various fixes for AdaptableModifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ heapless = "0.7.14"
 libm = "0.2.2"
 indexmap = "1.9.1"
 
+[features]
+default = ["std"]
+std = []
+
 [lib]
 name = "rcas"
 path = "src/lib.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 #![no_std]
 
+#[cfg(feature = "std")]
+extern crate std;
+
 use core::fmt;
 
 extern crate alloc;

--- a/src/modifier/adaptable_modifier.rs
+++ b/src/modifier/adaptable_modifier.rs
@@ -432,10 +432,13 @@ mod tests {
     use core::str::FromStr;
     use heapless::LinearMap;
 
+    #[cfg(feature = "std")]
+    use std::collections::hash_map::DefaultHasher;
+
     use super::{AdaptableModifier, ModifierImmutable};
     use crate::{
         expression::expression_tree::{Atom, Expression},
-        modifier::ModifierMutable,
+        modifier::{ModifierMutable, adaptable_modifier::CachingAdaptableMod},
     };
 
     #[test]
@@ -924,5 +927,19 @@ mod tests {
         modifier2.modify_mut(&mut expr_mut);
 
         assert_eq!(expr_mut, expected_expr);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_caching_am() {
+        use std::collections::hash_map::RandomState;
+
+        let mut modifier = CachingAdaptableMod::<RandomState>::from_str_list(vec![("_*1 - _*2", "_*1 + -_*2")], None);
+
+        let mut expr1 = Expression::from_str("1 - 2").unwrap();
+        let expected_expr1 = Expression::from_str("1 + -2").unwrap();
+        expr1.simplify::<CachingAdaptableMod<RandomState>, 50>(&mut modifier);
+
+        assert_eq!(expr1, expected_expr1);
     }
 }

--- a/src/modifier/adaptable_modifier.rs
+++ b/src/modifier/adaptable_modifier.rs
@@ -1,7 +1,7 @@
 use core::{
     fmt,
-    ops::{Add, AddAssign},
     hash::BuildHasher,
+    ops::{Add, AddAssign},
 };
 
 use alloc::{boxed::Box, vec, vec::Vec};
@@ -101,9 +101,7 @@ impl AdaptableModifier {
             ));
         }
 
-        Self {
-            search_tree,
-        }
+        Self { search_tree }
     }
 
     //derives an AdaptableModifier from a list of rules in Expression and Function form
@@ -114,9 +112,7 @@ impl AdaptableModifier {
             search_tree.insert((expression, function));
         }
 
-        Self {
-            search_tree,
-        }
+        Self { search_tree }
     }
 
     pub fn insert_rule(&mut self, expr: Expression, func: ModifierFunction) {
@@ -328,8 +324,10 @@ impl fmt::Display for AdaptableModifier {
 }
 
 //CachingAdaptableModifier: an AdaptableModifier that caches the results of its modifications
-struct CachingAdaptableMod<S> 
-where S: Default + BuildHasher {
+struct CachingAdaptableMod<S>
+where
+    S: Default + BuildHasher,
+{
     pub modifier: AdaptableModifier,
     //because modificiation is recursive and repetitive, we memoize the result of modification, to skip false results
     cache: IndexMap<Expression, bool, S>,
@@ -338,7 +336,9 @@ where S: Default + BuildHasher {
 }
 
 impl<S> CachingAdaptableMod<S>
-where S: Default + BuildHasher {
+where
+    S: Default + BuildHasher,
+{
     pub fn from_str_list(rules: Vec<(&str, &str)>, limit: Option<usize>) -> Self {
         let modifier = AdaptableModifier::from_str_list(rules);
 
@@ -366,9 +366,11 @@ where S: Default + BuildHasher {
 }
 
 impl<S> ModifierMutable for CachingAdaptableMod<S>
-where S: Default + BuildHasher {
+where
+    S: Default + BuildHasher,
+{
     fn modify_mut(&mut self, expression: &mut Expression) -> bool {
-        if let Some(_) = self.cache.get(expression) {
+        if self.cache.get(expression).is_some() {
             false
         } else {
             let mem_save = expression.clone();
@@ -378,10 +380,10 @@ where S: Default + BuildHasher {
             if !modified {
                 if let Some(limit) = self.limit {
                     if self.cache.len() >= limit {
-                        self.cache.drain(limit/2..limit);
+                        self.cache.drain(limit / 2..limit);
                     }
                 }
-                
+
                 self.cache.insert(mem_save, false);
             }
 
@@ -391,7 +393,9 @@ where S: Default + BuildHasher {
 }
 
 impl<S> Add<AdaptableModifier> for CachingAdaptableMod<S>
-where S: Default + BuildHasher {
+where
+    S: Default + BuildHasher,
+{
     type Output = Self;
 
     fn add(mut self, other: AdaptableModifier) -> Self {
@@ -402,14 +406,18 @@ where S: Default + BuildHasher {
 }
 
 impl<S> AddAssign<AdaptableModifier> for CachingAdaptableMod<S>
-where S: Default + BuildHasher {
+where
+    S: Default + BuildHasher,
+{
     fn add_assign(&mut self, other: AdaptableModifier) {
         self.modifier += other;
     }
 }
 
 impl<S> Add for CachingAdaptableMod<S>
-where S: Default + BuildHasher {
+where
+    S: Default + BuildHasher,
+{
     type Output = Self;
 
     fn add(mut self, other: Self) -> Self {
@@ -420,7 +428,9 @@ where S: Default + BuildHasher {
 }
 
 impl<S> AddAssign for CachingAdaptableMod<S>
-where S: Default + BuildHasher {
+where
+    S: Default + BuildHasher,
+{
     fn add_assign(&mut self, other: Self) {
         self.modifier += other.modifier;
     }
@@ -432,13 +442,10 @@ mod tests {
     use core::str::FromStr;
     use heapless::LinearMap;
 
-    #[cfg(feature = "std")]
-    use std::collections::hash_map::DefaultHasher;
-
     use super::{AdaptableModifier, ModifierImmutable};
     use crate::{
         expression::expression_tree::{Atom, Expression},
-        modifier::{ModifierMutable, adaptable_modifier::CachingAdaptableMod},
+        modifier::{adaptable_modifier::CachingAdaptableMod, ModifierMutable},
     };
 
     #[test]
@@ -934,7 +941,10 @@ mod tests {
     fn test_caching_am() {
         use std::collections::hash_map::RandomState;
 
-        let mut modifier = CachingAdaptableMod::<RandomState>::from_str_list(vec![("_*1 - _*2", "_*1 + -_*2")], None);
+        let mut modifier = CachingAdaptableMod::<RandomState>::from_str_list(
+            vec![("_*1 - _*2", "_*1 + -_*2")],
+            None,
+        );
 
         let mut expr1 = Expression::from_str("1 - 2").unwrap();
         let expected_expr1 = Expression::from_str("1 + -2").unwrap();

--- a/src/modifier/adaptable_modifier.rs
+++ b/src/modifier/adaptable_modifier.rs
@@ -324,7 +324,7 @@ impl fmt::Display for AdaptableModifier {
 }
 
 //CachingAdaptableModifier: an AdaptableModifier that caches the results of its modifications
-struct CachingAdaptableModifier<S>
+pub struct CachingAdaptableModifier<S>
 where
     S: Default + BuildHasher,
 {

--- a/src/modifier/adaptable_modifier.rs
+++ b/src/modifier/adaptable_modifier.rs
@@ -324,7 +324,7 @@ impl fmt::Display for AdaptableModifier {
 }
 
 //CachingAdaptableModifier: an AdaptableModifier that caches the results of its modifications
-struct CachingAdaptableMod<S>
+struct CachingAdaptableModifier<S>
 where
     S: Default + BuildHasher,
 {
@@ -335,7 +335,7 @@ where
     limit: Option<usize>,
 }
 
-impl<S> CachingAdaptableMod<S>
+impl<S> CachingAdaptableModifier<S>
 where
     S: Default + BuildHasher,
 {
@@ -365,7 +365,7 @@ where
     }
 }
 
-impl<S> ModifierMutable for CachingAdaptableMod<S>
+impl<S> ModifierMutable for CachingAdaptableModifier<S>
 where
     S: Default + BuildHasher,
 {
@@ -392,7 +392,7 @@ where
     }
 }
 
-impl<S> Add<AdaptableModifier> for CachingAdaptableMod<S>
+impl<S> Add<AdaptableModifier> for CachingAdaptableModifier<S>
 where
     S: Default + BuildHasher,
 {
@@ -405,7 +405,7 @@ where
     }
 }
 
-impl<S> AddAssign<AdaptableModifier> for CachingAdaptableMod<S>
+impl<S> AddAssign<AdaptableModifier> for CachingAdaptableModifier<S>
 where
     S: Default + BuildHasher,
 {
@@ -414,7 +414,7 @@ where
     }
 }
 
-impl<S> Add for CachingAdaptableMod<S>
+impl<S> Add for CachingAdaptableModifier<S>
 where
     S: Default + BuildHasher,
 {
@@ -427,7 +427,7 @@ where
     }
 }
 
-impl<S> AddAssign for CachingAdaptableMod<S>
+impl<S> AddAssign for CachingAdaptableModifier<S>
 where
     S: Default + BuildHasher,
 {
@@ -445,7 +445,7 @@ mod tests {
     use super::{AdaptableModifier, ModifierImmutable};
     use crate::{
         expression::expression_tree::{Atom, Expression},
-        modifier::{adaptable_modifier::CachingAdaptableMod, ModifierMutable},
+        modifier::{adaptable_modifier::CachingAdaptableModifier, ModifierMutable},
     };
 
     #[test]
@@ -941,14 +941,14 @@ mod tests {
     fn test_caching_am() {
         use std::collections::hash_map::RandomState;
 
-        let mut modifier = CachingAdaptableMod::<RandomState>::from_str_list(
+        let mut modifier = CachingAdaptableModifier::<RandomState>::from_str_list(
             vec![("_*1 - _*2", "_*1 + -_*2")],
             None,
         );
 
         let mut expr1 = Expression::from_str("1 - 2").unwrap();
         let expected_expr1 = Expression::from_str("1 + -2").unwrap();
-        expr1.simplify::<CachingAdaptableMod<RandomState>, 50>(&mut modifier);
+        expr1.simplify::<CachingAdaptableModifier<RandomState>, 50>(&mut modifier);
 
         assert_eq!(expr1, expected_expr1);
     }


### PR DESCRIPTION
- remove memoization from AdaptableModifier
- create new CachingAdaptableMod struct, which does memoization
  - has an optional limit on the size of the indexmap backing of the memoization (closes #47)
- create an std feature (breaking change: "std" is default)