### PR TITLE
Fix `parse_matrix` and `parse_vector` to accept empty literals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /.vscode
 /.idea
+/.fleet


### PR DESCRIPTION
Fixing the `parse_matrix` and `parse_vector` functions to allow for empty literals (`[]` and `<>`)